### PR TITLE
feat: enable optional attributes

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  experiments = [module_variable_optional_attrs]
   required_version = "~> 1.2.8"
 
   required_providers {


### PR DESCRIPTION
The usage of optional parameters as implemented by @ctxch in https://github.com/avaloqcloud/terraform-oci-container-instance/blob/main/variables.tf#L61 is the way to go to handle optional attributes in Terraform, since the feature is only GA in v1.3.0 of terraform I'm duplicating the future flag specification by @ctxch in this template repository as well to make it ORM compatible, since ORM does not support v1.3.0 yet. This will be definitely needed in most modules and would be good if we enable this by default.

Thanks @ctxch (: